### PR TITLE
Fix quoting for find command in Makefile

### DIFF
--- a/villain/Makefile
+++ b/villain/Makefile
@@ -38,4 +38,4 @@ str.o: str.c
 
 clean:
 	rm -f *.o *.s
-	find . -name *.run -delete
+	find . -name "*.run" -delete


### PR DESCRIPTION
The `clean` target didn't work if a `.run` file existed in `villain/` directory. 