### PR TITLE
Makefile cleanup

### DIFF
--- a/stdlibs.md
+++ b/stdlibs.md
@@ -13,10 +13,14 @@ To add a new standard library, "mystdlib":
    where `f1`, `f2`, ... `fn` are the functions provided by "mystdlib".
 3. In
    `villain/externs.rkt", append the ids provided by "mystdlib" to the list of symbols defined by `stdlib-ids`.
-4. In `villain/Makefile`:
-   1. In the `stdlib` label, append the command `make mystdlib.o`.
-   2. In the `runtime.o` label, add `stdlib.o` to the list of object files
-      passed to `ld`'s `-r` option (right before the `-o` option)
+4. In `villain/Makefile`, append `mystdlib.o` to the list `objs_lib`.
+   ```diff
+    objs_lib = \
+    	math.o \
+   -	list.o
+   +	list.o \
+   +	mystdlib.o
+   ```
 
 After doing these steps, the ids provided by "mystdlib" should be available to
 all programs. Making an executable via `%.run` will automatically make all

--- a/villain/Makefile
+++ b/villain/Makefile
@@ -1,5 +1,5 @@
 UNAME := $(shell uname)
-.PHONY: test std
+.PHONY: test std default
 
 ifeq ($(UNAME), Darwin)
   format=macho64
@@ -9,31 +9,39 @@ else
   libs='-l:libunistring.a'
 endif
 
+objs_lib = \
+	math.o \
+	list.o
+
+objs = \
+	$(objs_lib) \
+	main.o \
+	char.o \
+	io.o \
+	symbol.o \
+	str.o
+
+default: runtime.o
+
+main.o: types.h runtime.h
+char.o: types.h
+io.o: runtime.h
+symbol.o: str.h
+
 %.run: %.o runtime.o
 	gcc runtime.o $< -o $@ $(libs) -lm
 
-runtime.o: main.o char.o io.o symbol.o str.o math.o list.o
-	ld -r main.o char.o io.o symbol.o str.o list.o math.o -o runtime.o
+runtime.o: $(objs)
+	ld -r $(objs) -o runtime.o
 
-main.o: main.c types.h runtime.h
-	gcc -fPIC -c main.c -o main.o
+.SUFFIXES: .c .s .o .rkt
+.c.o:
+	gcc -fPIC -c -o $@ $< 
 
-char.o: char.c types.h
-	gcc -fPIC -c char.c -o char.o
-
-io.o: io.c runtime.h
-	gcc -fPIC -c io.c -o io.o
-
-symbol.o: symbol.c str.h
-	gcc -fPIC -c symbol.c -o symbol.o
-
-str.o: str.c
-	gcc -fPIC -c str.c -o str.o
-
-%.o: %.s
+.s.o:
 	nasm -f $(format) -o $@ $<
 
-%.s: %.rkt
+.rkt.s:
 	racket -t compile-file.rkt -m $< > $@
 
 clean:


### PR DESCRIPTION
I replaced the boilerplate in `Makefile` with suffix rules. Adding a new object file now only requires adding one line of code

```diff
 objs_lib = \
 	math.o \
-	list.o
+	list.o \
+	mystdlib.o
```