### PR TITLE
Calling convention: return address over args

### DIFF
--- a/villain/compile.rkt
+++ b/villain/compile.rkt
@@ -32,7 +32,7 @@
            (Extern 'str_to_symbol)
            (Label 'entry)
            (Mov rbx rdi) ; recv heap pointer
-           (compile-e e '(#f))
+           (compile-e e '())
            (Mov rdx rbx) ; return heap pointer in second return register           
            (Ret)
            (compile-defines ds)
@@ -63,7 +63,7 @@
           (compile-provides xs))]))
 
 (define (error-label c)
-  (if (odd? (length c))
+  (if (even? (length c))
       'raise_error
       'raise_error_align))
 
@@ -82,11 +82,9 @@
      (seq (Label (symbol->label f)) 
           (Cmp rcx (imm->bits (length xs))) ; arity check
           (Jne 'raise_error)
-          (compile-e e (parity (cons #f (reverse xs))))
+          (compile-e e (reverse xs))
           ; return
-          (Pop r8) ; save rp
           (Add rsp (* 8 (length xs))) ; pop args
-          (Push r8) ; replace rp
           (Ret))]
     [(Defn* f xs xs* e) 
      (let ((loop (gensym 'loop))
@@ -95,7 +93,6 @@
        (seq (Label (symbol->label f))
             (Cmp rcx (imm->bits (length xs)))
             (Jl 'raise_error)
-            (Pop r10)                         ; store return address
             (Mov rax (imm->bits '()))         ; initialize rest arg
             (Sub rcx (imm->bits (length xs))) ; # of things to pop off of stack
 
@@ -113,18 +110,10 @@
             (Label end)
 
             (Push rax) ; push the rest list
-            (Push r10) ; reinstall return address
-            (compile-e e (parity (cons #f (cons xs* (reverse xs)))))
+            (compile-e e (cons xs* (reverse xs)))
             ; return
-            (Pop r10)  ; save rp
             (Add rsp (* 8 (add1 (length xs)))) ; pop args
-            (Push r10) ; replace rp
             (Ret)))]))
-
-(define (parity c)
-  (if (even? (length c))
-      (append c (list #f))
-      c))
 
 ;; Expr CEnv -> Asm
 (define (compile-e e c)
@@ -504,21 +493,25 @@
                  (Mov rax val-void)))])))                   
 
 ;; Id [Listof Expr] CEnv -> Asm
-;; Here's why this code is so gross: you have to align the stack for the call
-;; but you have to do it *before* evaluating the arguments es, because you need
-;; es's values to be just above 'rsp when the call is made.  But if you push
-;; a frame in order to align the call, you've got to compile es in a static
-;; environment that accounts for that frame, hence:
+;; The return address is placed above the arguments, so callee pops
+;; arguments and return address is next frame
 (define (compile-app f es c)
-  (if (even? (+ (length es) (length c))) 
-      (seq (compile-es es c) 
-           (Mov rcx (imm->bits (length es)))
-           (Call (symbol->label f)))            ; pop args
-      (seq (Sub rsp 8)                          ; adjust stack
-           (compile-es es (cons #f c))
-           (Mov rcx (imm->bits (length es)))
-           (Call (symbol->label f))
-           (Add rsp 8))))
+  (let ((ret (gensym 'ret)))
+    (if (odd? (+ (length es) (length c)))
+        (seq (Lea r8 ret)
+             (Push r8)
+             (compile-es es (cons #f c))
+             (Mov rcx (imm->bits (length es)))
+             (Jmp (symbol->label f))
+             (Label ret))
+        (seq (Sub rsp 8)
+             (Lea r8 ret)
+             (Push r8)
+             (compile-es es (cons #f (cons #f c)))
+             (Mov rcx (imm->bits (length es)))
+             (Jmp (symbol->label f))
+             (Label ret)
+             (Add rsp 8)))))
 
 ;; [Listof Expr] CEnv -> Asm
 (define (compile-es es c)
@@ -634,7 +627,7 @@
 ;; CEnv -> Asm
 ;; Pad the stack to be aligned for a call with stack arguments
 (define (pad-stack-call c i)
-  (match (even? (+ (length c) i))
+  (match (odd? (+ (length c) i))
     [#f (seq (Sub rsp 8) (% "padding stack"))]
     [#t (seq)]))
 
@@ -646,7 +639,7 @@
 ;; CEnv -> Asm
 ;; Undo the stack alignment after a call
 (define (unpad-stack-call c i)
-  (match (even? (+ (length c) i))
+  (match (odd? (+ (length c) i))
     [#f (seq (Add rsp 8) (% "unpadding"))]
     [#t (seq)]))
 


### PR DESCRIPTION
This changes the calling convention to place the return address above
rather than below the arguments.  This has the nice benefit of making
it possible to eliminate the `parity` thing for reconstructing whether
you were called in a padded stack or not.  It also seems basically
required to implement tail calls since a tail called function has to
pop all of its local variables and arguments off, but previously these
had a return pointer in the middle of it all.  This simplifies the
callee pop (no more saving/restoring return address), but it slightly
complicates calls, since we have to put arguments below the return
address it's not possible to use a `Call` instruction without
violating the property that there's nothing below `rsp`.  The solution
is to simulate `Call` by labelling the returning point, pushing it,
then the args, then jumping to the function.