### PR TITLE
Updates Double Precision Floating Point Operations and a86

### DIFF
--- a/a86/printer.rkt
+++ b/a86/printer.rkt
@@ -148,7 +148,25 @@
       [(Bsr a1 a2)
        (string-append tab "bsr "
                       (arg->string a1) ", "
-                      (arg->string a2))]))
+                      (arg->string a2))]
+
+       [(Addsd a1 a2)
+       (string-append tab "addsd "
+                      (arg->string a1) ", "
+                      (arg->string a2))]
+
+       [(Subsd a1 a2)
+       (string-append tab "subsd "
+                      (arg->string a1) ", "
+                      (arg->string a2))]
+
+      [(Movapd a1 a2)
+       (string-append tab "movapd "
+                      (arg->string a1) ", "
+                      (arg->string a2))]
+
+      
+      ))
 
 
   (define (comment->string c)

--- a/villain/compile.rkt
+++ b/villain/compile.rkt
@@ -718,11 +718,11 @@
                  (Label eq-true)))]
 
 
-             ['fl<=
+         ['fl<=
           (let ((leq-true (gensym 'leq)))
             (seq (Pop r8)
                  (assert-flonum r8 c)
-               (assert-flonum rax c)
+                 (assert-flonum rax c)
                  (Xor rax type-flonum)
                  (Mov rax (Offset rax 0))
                  (Xor r8 type-flonum)
@@ -731,7 +731,7 @@
                  (Xor rax r9)
                  (Mov r10 (arithmetic-shift 1 63))
                  (Xor r8 r10)
-                 (Cmp r8 r9)
+                 (Cmp r8 rax)
                  (Mov rax (imm->bits #t))
                  (Jle leq-true)
                  (Mov rax (imm->bits #f))

--- a/villain/compile.rkt
+++ b/villain/compile.rkt
@@ -12,19 +12,16 @@
                   ; make-string, compile-prim3, string-ref!, integer-length, match,
                   ; compile-define, open-input-file
 (define r9  'r9)  ; scratch in assert-type, compile-str-chars, string-ref,
-                  ; string-set!, make-string, compile-define, compile-fl+
+                  ; string-set!, make-string, compile-define
                   ; compile-vector, vector-set!, vector-ref
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
 (define rsi 'rsi) ; arg2
 (define r10 'r10) ; scratch in compile-prim3, make-string, string-set!, compile-vector, vector-set!
-                  ; compile-define, compile-fl+
-(define r11 'r11) ; scratch in compile-fl+
-(define r12 'r12) ; scratch in compile-fl+
-(define r13 'r13) ; scratch in compile-fl+
+                  ; compile-define
 (define rcx 'rcx) ; arity indicator
 (define al  'al)  ; low byte of rax ; open-input-file
-(define xmm0 'xmm0)
+(define xmm0 'xmm0) ; registers to hold double precision floating numbers
 
 ;; type CEnv = [Listof Variable]
 

--- a/villain/compile.rkt
+++ b/villain/compile.rkt
@@ -12,13 +12,13 @@
                   ; make-string, compile-prim3, string-ref!, integer-length, match,
                   ; compile-define, open-input-file
 (define r9  'r9)  ; scratch in assert-type, compile-str-chars, string-ref,
-                  ; string-set!, make-string, compile-define
+                  ; string-set!, make-string, compile-define, fl<=
                   ; compile-vector, vector-set!, vector-ref
 (define rsp 'rsp) ; stack
 (define rdi 'rdi) ; arg
 (define rsi 'rsi) ; arg2
 (define r10 'r10) ; scratch in compile-prim3, make-string, string-set!, compile-vector, vector-set!
-                  ; compile-define
+                  ; compile-define, fl<=
 (define rcx 'rcx) ; arity indicator
 (define al  'al)  ; low byte of rax ; open-input-file
 (define xmm0 'xmm0) ; registers to hold double precision floating numbers
@@ -727,13 +727,11 @@
                  (Mov rax (Offset rax 0))
                  (Xor r8 type-flonum)
                  (Mov r8 (Offset r8 0))
-                 (Mov r9 rax)
-                 (Mov r11 (arithmetic-shift 1 63))
-                 (Xor r9 r11)
-                 (Mov r10 r8)
-                 (Mov r12 (arithmetic-shift 1 63))
-                 (Xor r10 r12)
-                 (Cmp r10 r9)
+                 (Mov r9 (arithmetic-shift 1 63))
+                 (Xor rax r9)
+                 (Mov r10 (arithmetic-shift 1 63))
+                 (Xor r8 r10)
+                 (Cmp r8 r9)
                  (Mov rax (imm->bits #t))
                  (Jle leq-true)
                  (Mov rax (imm->bits #f))

--- a/villain/wrap.c
+++ b/villain/wrap.c
@@ -113,21 +113,8 @@ vl_val vl_wrap_str(vl_str *s)
 
 double vl_unwrap_flonum(vl_val x)
 {
-  int64_t f = *((int64_t *)(x ^ flonum_type_tag));
+ return *((double *)(x ^ flonum_type_tag));
 
-  int sign= 1 & (f >> 63) ? -1 : 1;
-  int64_t exp = (((1 << 11) - 1) & (f >> 52));
-  int64_t mantissa = (((int64_t)1 << 52) - 1) & f;
-  double dec_man = 0;
-
-  for (int i = -52; i < 0; i++) {
-    if (1 == (1 & mantissa)) {
-      dec_man += 1 << i;
-    }
-    mantissa >>= 1;
-  }
-
-  return sign * (1<<(exp - 0x3ff)) * (1 + dec_man);
 }
 vl_val vl_wrap_flonum(double f)
 {


### PR DESCRIPTION
This is my update to my implementation of the Floating point numbers to decrease lines of code. 

**Idea:**

Instead of implementing `fl+` and `fl-` from scratch, uses the `addsd` and `subsd` instruction. To do this, I implemented an xmm register, `xmm0`, in a86. 

`a86/ast.rkt`
- Updates `register?` for the case of xmm0
- Adds `xregister?` function to check for xmm registers
- Adds `Addsd`, `Subsd`, `Movapd` instructions.
- Adds `check:xsrc-xdest` function to check the instruction to see if it only moves xmm registers and memory addresses.
- Adds `check:arith` function to check the instruction to see if it only has two xmm registers or one xmm register and a memory address

`a86/printer.rkt`
- Adds `Addsd`, `Subsd`, `Movapd` cases.

`compile.rkt`
- Updated the case for `fl+` and `fl-` by using `addsd` and `subsd` respectively
- Removed `compile-fl+`
- Reduced the registers in the file
- Changed the `fl=` case by not using r10 and r11 as scratch registers

`wrap.c`
- Updates `vl_unwrap_flonum`, so C can unwrap the unboxed flonum directly 