### PR TITLE
Working heap overflow detection.

### DIFF
--- a/villain/main.c
+++ b/villain/main.c
@@ -126,7 +126,8 @@ int main(int argc, char** argv)
   error_handler = &error_exit;
   heap = vl_calloc(8 * heap_size, 1);
 
-  result = entry(heap);
+  result = entry(heap, heap + (heap_size - heap_buffer));
+  // result = entry(heap);
 
   print_result(result);
   if (vl_typeof(result) != VL_VOID)

--- a/villain/runtime.h
+++ b/villain/runtime.h
@@ -8,6 +8,8 @@ extern void (*error_handler)();
 
 // in words
 #define heap_size 10000
+// maximum number of words we expect to allocate before checking heap ptr.
+#define heap_buffer 2
 extern int64_t *heap;
 
 #endif


### PR DESCRIPTION
Stores pointer to end of heap in r15 and compares using check-heap-ptr command sequence.

I tested the heap overflow detection by making the heap size 5, and the running with and without overflow detection. Without, it segfaulted. With, it failed by returning the error code but didn't segfault.